### PR TITLE
feat: add marketplace badge to cron-tasks

### DIFF
--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -15,6 +15,21 @@ permissions:
     pull-requests: read
 
 jobs:
+  badge-marketplace:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - id: marketplace-badge
+      uses: tagdots/setup-badge-action@3989b8b5c1c81c961b76d125c8ea50fc7739d9cf # 1.0.0
+      with:
+        badge-name: marketplace
+        badge-url: https://github.com/marketplace/actions/setup-badge-action
+        label: Marketplace
+        message: setup-badge-action
+        message-color: FF6360
+
   stale-workflows: # https://github.com/Mattraks/delete-workflow-runs
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Summary
Add marketplace-badge to cron-tasks