### PR TITLE
fix: cron-tasks is missing badge-marketplace in overall results and slack message

### DIFF
--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -66,7 +66,7 @@ jobs:
 
   notify-slack:
     if: always()
-    needs: [stale-workflows, update-pre-commit]
+    needs: [badge-marketplace, stale-workflows, update-pre-commit]
 
     runs-on: ubuntu-latest
 
@@ -80,7 +80,7 @@ jobs:
       shell: bash
       run: |
         # get overall result from all of the previous jobs
-        if "${{ needs.stale-workflows.result == 'success' && needs.update-pre-commit.result == 'success' }}"; then
+        if "${{ needs.badge-marketplace.result == 'success' && needs.stale-workflows.result == 'success' && needs.update-pre-commit.result == 'success' }}"; then
           echo "WORKFLOW_RESULT=:white_check_mark:" >> "$GITHUB_OUTPUT"
         else
           echo "WORKFLOW_RESULT=:no_entry:" >> "$GITHUB_OUTPUT"
@@ -98,6 +98,7 @@ jobs:
               *Workflow : ${{ github.workflow }} ${{ steps.get-overall-jobs-results.outputs.WORKFLOW_RESULT }}*
               ```
               URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n
+              Job: badge-marketplace - ${{ needs.badge-marketplace.result }}\n
               Job: stale-workflows   - ${{ needs.stale-workflows.result }}\n
               Job: update-pre-commit - ${{ needs.stale-branches.result }}
               ```"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This action runs [setup-badge](https://github.com/tagdots/setup-badge) to genera
 
 ## ⭐ How setup-badge-action works
 
-**setup-badge-action** triggers **setup-badge** workflow below.
+**setup-badge-action** runs **setup-badge** workflow below.
 
 1. **setup-badge** runs with [command line options](https://github.com/tagdots/setup-badge-action?tab=readme-ov-file#-setup-badge-command-line-options).
 1. **setup-badge** adds/updates a json file from your options.
@@ -54,6 +54,7 @@ permissions:
 jobs:
   language-badge:
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
 
@@ -68,6 +69,7 @@ jobs:
 
   license-badge:
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
 
@@ -109,6 +111,7 @@ permissions:
 jobs:
   coverage-badge:
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 name: setup-badge-action
 
-description: 'Run setup-badge to create shield.io endpoint badges to showcase on your README'
+description: 'Run setup-badge to create shields.io endpoint badges to showcase on your README'
 
 author: tagdots
 


### PR DESCRIPTION
### Summary
- add missing badge-marketplace to overall result and Slack message
- correct typo shield.io to shields.io in action description
- add some newlines for easy reading
