### PR TITLE
bump: version 1.0.2 → 1.0.3

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -4,6 +4,6 @@ commitizen:
   name: cz_conventional_commits
   tag_format: $version
   update_changelog_on_bump: true
-  version: 1.0.2
+  version: 1.0.3
   version_provider: commitizen
   version_scheme: pep440

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.3 (2025-07-25)
+
+### Feat
+
+- add marketplace badge to cron-tasks
+
+### Fix
+
+- cron-tasks is missing badge-marketplace in overall results and slack message
+
 ## 1.0.2 (2025-07-25)
 
 ## 1.0.1 (2025-07-25)


### PR DESCRIPTION
### Summary
This PR bumps version from 1.0.2 to 1.0.3